### PR TITLE
Upgrade to PHP 8 and Varnish 6.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,45 +1,49 @@
-FROM studionone/apache-php:7.3
+FROM studionone/apache-php:8.0
+
+ENV VARNISH_VERSION 6.5.2~stretch-1
 
 # Varnish is being installed from source because we need to VCL mod to allow for dynamic configurations
-RUN apt-get update && apt-get install -y autoconf \
+RUN apt-get update && apt-get install -y \
+      autoconf \
       automake \
       autotools-dev \
       libedit-dev \
       libjemalloc-dev \
       libncurses-dev \
       libpcre3-dev \
+      libvarnishapi-dev \
       libtool \
       pkg-config \
       python-docutils \
       python-sphinx \
       apt-transport-https \
+      debian-archive-keyring \
       wget
 
 # Add the Varnish Cache gpg key to the keyring used by APT:
-RUN wget https://packagecloud.io/varnishcache/varnish60lts/gpgkey -O - | apt-key add - \
-    && apt-get install apt-transport-https debian-archive-keyring -y \
-    && echo "deb https://packagecloud.io/varnishcache/varnish60lts/debian/ stretch main" | tee -a /etc/apt/sources.list.d/varnishcache_varnish60lts.list \
-    && echo "deb-src https://packagecloud.io/varnishcache/varnish60lts/debian/ stretch main" | tee -a /etc/apt/sources.list.d/varnishcache_varnish60lts.list
+RUN wget https://packagecloud.io/varnishcache/varnish65/gpgkey -O - | apt-key add - \
+    && echo "deb https://packagecloud.io/varnishcache/varnish65/debian/ stretch main" | tee -a /etc/apt/sources.list.d/varnishcache_varnish65.list \
+    && echo "deb-src https://packagecloud.io/varnishcache/varnish65/debian/ stretch main" | tee -a /etc/apt/sources.list.d/varnishcache_varnish65.list \
+    && echo "deb http://ftp.au.debian.org/debian stretch main " | tee -a /etc/apt/sources.list # to install libjemalloc1
 
 # Varnish
-RUN apt-get update && apt-get install -y \
-     varnish \
-     varnish-dev \
-    && cd /tmp \
-      && wget https://github.com/Dridi/libvmod-querystring/releases/download/v2.0.1/vmod-querystring-2.0.1.tar.gz \
-      && tar xfz vmod-querystring-2.0.1.tar.gz \
-      && rm -rf /tmp/vmod-querystring-2.0.1.tar.gz
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    varnish=$VARNISH_VERSION \
+    varnish-dev=$VARNISH_VERSION
 
 # Varnish querystring module
-RUN cd /tmp/vmod-querystring-2.0.1 \
-      && sh configure \
-      && make \
-      && make install \
-      && cd ../ \
-      && rm -rf /tmp/vmod-querystring-2.0.1 \
-      && ldconfig
+RUN cd /tmp \
+    && wget https://github.com/Dridi/libvmod-querystring/releases/download/v2.0.2/vmod-querystring-2.0.2.tar.gz \
+    && tar xfz vmod-querystring-2.0.2.tar.gz \
+    && rm -rf /tmp/vmod-querystring-2.0.2.tar.gz \
+    && cd /tmp/vmod-querystring-2.0.2 \
+    && sh configure \
+    && make \
+    && make install \
+    && cd ../ \
+    && rm -rf /tmp/vmod-querystring-2.0.2 \
+    && ldconfig
 
 # Varnish defult configuration file
 COPY conf/default.vcl.m4 /opt/default.vcl.m4
 COPY conf/supervisor_conf.d/varnish.conf /etc/supervisor/conf.d/varnish.conf
-

--- a/conf/supervisor_conf.d/varnish.conf
+++ b/conf/supervisor_conf.d/varnish.conf
@@ -1,5 +1,5 @@
 [program:varnish]
-command=varnishd -F -f /etc/varnish/default.vcl -s malloc,100m -a 0.0.0.0:8080 -p http_req_hdr_len=16384 -p http_resp_hdr_len=16384 -p workspace_client=128k
+command=varnishd -F -f /etc/varnish/default.vcl -s malloc,100m -a 0.0.0.0:8080 -p http_req_hdr_len=16384 -p http_resp_hdr_len=16384 -p workspace_client=128k -p feature=+http2
 priority=998
 user=root
 autostart=true


### PR DESCRIPTION
## Pull request checklist

<!-- To check a box replace the space with an x e.g. [x] -->

This PR fulfils the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Documentation has been reviewed and added/updated where required
- [x] Linting has been run locally and fixes applied for any issues

## Pull request type

<!-- Limit pull requests to one type where possible, submit multiple pull requests if needed -->

This PR introduces the following types of changes:

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Code Style
- [ ] Documentation
- [ ] Other: <!-- If selected, describe the type -->

## Link to issue/card

<!-- Include links to the relevant trello, jira, or similar items -->

## What is the current behaviour?

The current image uses PHP 7.3 and Varnish 6.0. 

## What is the new behaviour?

The new image uses PHP 8.0 and Varnish 6.5.2. Also, HTTP/2 is enabled by default

## Does this introduce a breaking change?

<!-- If this introduces a breaking change, describe the impact and migration path for existing applications below -->

- [x] Yes
- [ ] No

## Other information

The image has been built and available by referencing `studionone/apache-php-varnish:8.0-varnish6.5`
